### PR TITLE
Fix hierarchical URL doc comment

### DIFF
--- a/src/modules/utils/hierarchical-url.service.ts
+++ b/src/modules/utils/hierarchical-url.service.ts
@@ -20,7 +20,8 @@ export class HierarchicalUrlService {
       .replace(/\-\-+/g, '-') // Replace multiple hyphens with single hyphen
       .replace(/^-+/, '') // Remove leading hyphens
       .replace(/-+$/, ''); // Remove trailing hyphens
-  } /**
+  }
+  /**
    * Generate hierarchical URL for a park
    */
   static generateParkUrl(


### PR DESCRIPTION
## Summary
- fix comment placement in HierarchicalUrlService

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module 'path' and others)*

------
https://chatgpt.com/codex/tasks/task_e_6858fe0f7a78832589283f1de405ec3e