### PR TITLE
Fix Smart Park Status header emoji

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,7 +17,7 @@ info:
     - **Type-Safe API**: Proper parameter validation and type conversion
     - **Comprehensive Coverage**: Theme parks worldwide with detailed ride information
 
-    ## � Smart Park Status Logic
+    ## 🎯 Smart Park Status Logic
 
     Parks are dynamically classified as "open" or "closed" based on operational rides:
     - **Threshold-based**: Parks with ≥X% operational rides are "open" (default: 50%)


### PR DESCRIPTION
## Summary
- replace garbled character in Smart Park Status Logic heading

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859024a46748325914cd96a8fa36c87