### PR TITLE
Fix YAML parsing errors

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -150,7 +150,8 @@ paths:
           description: Filter parks by continent
           required: false
           schema:
-            type: string        - name: country
+            type: string
+        - name: country
           in: query
           description: Filter parks by country
           required: false
@@ -210,7 +211,8 @@ paths:
             oneOf:
               - type: integer
                 description: Numeric park ID
-              - type: string                description: Continent name for hierarchical navigation
+              - type: string
+                description: Continent name for hierarchical navigation
         - name: openThreshold
           in: query
           description: Percentage threshold for considering a park "open"
@@ -567,7 +569,8 @@ components:
         isOpen:
           type: boolean
           description: Whether the park is currently considered "open" based on ride availability
-          example: true        rides:
+          example: true
+        rides:
           type: array
           description: List of rides in the park (included when fetching specific park)
           items:


### PR DESCRIPTION
## Summary
- fix indentation around park filtering parameters in openapi.yaml
- ensure proper newline after `example: true`
- parse `openapi.yaml` with PyYAML to ensure validity

## Testing
- `python3 - <<'EOF'
import yaml
yaml.safe_load(open('openapi.yaml'))
print('YAML parsed successfully')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685902505f4483258c77717faae0508c