### PR TITLE
Fix blank line before comment

### DIFF
--- a/src/modules/utils/hierarchical-url.service.ts
+++ b/src/modules/utils/hierarchical-url.service.ts
@@ -21,6 +21,7 @@ export class HierarchicalUrlService {
       .replace(/^-+/, '') // Remove leading hyphens
       .replace(/-+$/, ''); // Remove trailing hyphens
   }
+
   /**
    * Generate hierarchical URL for a park
    */


### PR DESCRIPTION
## Summary
- add newline before the `generateParkUrl` comment in `hierarchical-url.service.ts`

## Testing
- `pnpm install`
- `pnpm lint` *(fails: Unsafe member access, etc.)*
- `pnpm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68590262a51083259ee1990397587fad