### PR TITLE
Fix DB indexes and document status endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -104,6 +104,24 @@ paths:
               schema:
                 type: string
 
+  /status:
+    get:
+      summary: API Status
+      description: Simple health check endpoint returning `{"status":"OK"}`.
+      tags:
+        - Health
+      responses:
+        '200':
+          description: Service is running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: OK
+
   /parks:
     get:
       summary: Get All Parks

--- a/src/modules/parks/park.entity.ts
+++ b/src/modules/parks/park.entity.ts
@@ -11,9 +11,10 @@ import { ThemeArea } from './theme-area.entity';
 import { Ride } from './ride.entity';
 
 @Entity()
-@Index('IDX_PARK_NAME')
-@Index('IDX_PARK_COUNTRY')
-@Index('IDX_PARK_CONTINENT')
+// Individual indexes to speed up lookups by park attributes
+@Index('IDX_PARK_NAME', ['name'])
+@Index('IDX_PARK_COUNTRY', ['country'])
+@Index('IDX_PARK_CONTINENT', ['continent'])
 @Index('IDX_PARK_QUEUE_TIMES_ID', ['queueTimesId'])
 @Index('IDX_PARK_CONT_COUNTRY_NAME', ['continent', 'country', 'name'])
 export class Park {

--- a/src/modules/parks/ride.entity.ts
+++ b/src/modules/parks/ride.entity.ts
@@ -13,7 +13,8 @@ import { QueueTime } from './queue-time.entity';
 
 @Entity()
 @Unique(['queueTimesId', 'park']) // Unique constraint on queueTimesId + park combination
-@Index('IDX_RIDE_NAME')
+// Index on ride name for fast lookup
+@Index('IDX_RIDE_NAME', ['name'])
 @Index('IDX_RIDE_PARK_NAME', ['park', 'name'])
 export class Ride {
   @PrimaryGeneratedColumn()

--- a/src/modules/parks/theme-area.entity.ts
+++ b/src/modules/parks/theme-area.entity.ts
@@ -12,7 +12,8 @@ import { Ride } from './ride.entity';
 
 @Entity()
 @Unique(['queueTimesId', 'park'])
-@Index('IDX_THEME_AREA_NAME')
+// Index on theme area name for quick filtering
+@Index('IDX_THEME_AREA_NAME', ['name'])
 @Index('IDX_THEME_AREA_PARK_NAME', ['park', 'name'])
 export class ThemeArea {
   @PrimaryGeneratedColumn()

--- a/src/modules/status/status.e2e.spec.ts
+++ b/src/modules/status/status.e2e.spec.ts
@@ -1,0 +1,28 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { StatusModule } from './status.module';
+
+describe('Status endpoint', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [StatusModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.listen(0);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/status returns OK', async () => {
+    await request(app.getHttpServer())
+      .get('/status')
+      .expect(200)
+      .expect({ status: 'OK' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a `/status` section to OpenAPI
- specify columns for ride, theme area and park indexes

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68593825a2d08325b489453b62bf3843