### PR TITLE
Add utility tests and small optimizations

### DIFF
--- a/src/modules/statistics/statistics.service.ts
+++ b/src/modules/statistics/statistics.service.ts
@@ -403,8 +403,10 @@ export class StatisticsService {
     const threshold = openThreshold ?? this.getDefaultOpenThreshold();
 
     return parks
-      .filter((park) => this.calculateParkOpenStatus(park, threshold)) // Use provided threshold
       .map((park) => {
+        if (!this.calculateParkOpenStatus(park, threshold)) {
+          return null;
+        }
         const allRides = this.parkUtils.getAllRidesFromPark(park);
 
         // All open rides (for count and percentage) - match the logic in calculateParkOpenStatus
@@ -468,8 +470,10 @@ export class StatisticsService {
     const threshold = openThreshold ?? this.getDefaultOpenThreshold();
 
     return parks
-      .filter((park) => this.calculateParkOpenStatus(park, threshold)) // Use provided threshold
       .map((park) => {
+        if (!this.calculateParkOpenStatus(park, threshold)) {
+          return null;
+        }
         const allRides = this.parkUtils.getAllRidesFromPark(park);
 
         // All open rides (for count and percentage) - match the logic in calculateParkOpenStatus

--- a/src/modules/utils/hierarchical-url-injector.service.spec.ts
+++ b/src/modules/utils/hierarchical-url-injector.service.spec.ts
@@ -1,0 +1,35 @@
+import { HierarchicalUrlInjectorService } from './hierarchical-url-injector.service';
+
+describe('HierarchicalUrlInjectorService', () => {
+  const service = new HierarchicalUrlInjectorService();
+
+  it('adds hierarchical URLs using nested park data', () => {
+    const ride: any = {
+      name: 'Ride X',
+      park: { id: 1, name: 'Park Y', continent: 'Europe', country: 'Germany' },
+    };
+
+    const result = service.addUrlToRide(ride);
+    expect(result.hierarchicalUrl).toBe('/parks/europe/germany/park-y/ride-x');
+    expect(result.park.hierarchicalUrl).toBe('/parks/europe/germany/park-y');
+  });
+
+  it('falls back to context when park data is incomplete', () => {
+    const ride: any = {
+      name: 'Ride Z',
+      park: { id: 1, continent: '', country: '' },
+    };
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = service.addUrlToRide(ride, {
+      continent: 'Europe',
+      country: 'Germany',
+      name: 'Park Z',
+    });
+
+    warnSpy.mockRestore();
+
+    expect(result.hierarchicalUrl).toBe('/parks/europe/germany/park-z/ride-z');
+    expect(result.park.hierarchicalUrl).toBe('/parks/unknown/unknown/unknown');
+  });
+});

--- a/src/modules/utils/hierarchical-url-injector.service.ts
+++ b/src/modules/utils/hierarchical-url-injector.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { HierarchicalUrlService } from './hierarchical-url.service.js';
+import { HierarchicalUrlService } from './hierarchical-url.service';
 
 @Injectable()
 export class HierarchicalUrlInjectorService {

--- a/src/modules/utils/park-utils.service.spec.ts
+++ b/src/modules/utils/park-utils.service.spec.ts
@@ -1,0 +1,59 @@
+import { Test } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { ParkUtilsService } from './park-utils.service';
+
+describe('ParkUtilsService', () => {
+  let service: ParkUtilsService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ isGlobal: true })],
+      providers: [ParkUtilsService],
+    }).compile();
+
+    service = moduleRef.get(ParkUtilsService);
+  });
+
+  it('merges rides from theme areas and park without duplicates', () => {
+    const ride1: any = { id: 1, name: 'R1', isActive: true, queueTimes: [] };
+    const ride2: any = { id: 2, name: 'R2', isActive: true, queueTimes: [] };
+    const park: any = {
+      id: 1,
+      name: 'Park',
+      country: 'X',
+      continent: 'Y',
+      themeAreas: [{ id: 1, name: 'Area', rides: [ride1, ride2] }],
+      rides: [ride2],
+    };
+
+    const rides = service.getAllRidesFromPark(park);
+    expect(rides).toHaveLength(2);
+    expect(rides.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('calculates park open status based on threshold', () => {
+    const now = new Date();
+    const openRide: any = {
+      id: 1,
+      name: 'Open',
+      isActive: true,
+      queueTimes: [{ waitTime: 10, isOpen: true, lastUpdated: now }],
+    };
+    const closedRide: any = {
+      id: 2,
+      name: 'Closed',
+      isActive: true,
+      queueTimes: [{ waitTime: 0, isOpen: false, lastUpdated: now }],
+    };
+    const park: any = {
+      id: 1,
+      name: 'Park',
+      country: 'X',
+      continent: 'Y',
+      themeAreas: [{ id: 1, name: 'Area', rides: [openRide, closedRide] }],
+    };
+
+    expect(service.calculateParkOpenStatus(park, 50)).toBe(true);
+    expect(service.calculateParkOpenStatus(park, 80)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `ParkUtilsService`
- cover `HierarchicalUrlInjectorService` with tests and adjust import
- avoid double calls to `calculateParkOpenStatus` in `StatisticsService`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685951c874008325bb38b66014e1bcb8