### PR TITLE
Optimize park open status queries

### DIFF
--- a/src/modules/parks/queue-time.entity.ts
+++ b/src/modules/parks/queue-time.entity.ts
@@ -11,6 +11,8 @@ import { Ride } from './ride.entity';
 @Entity()
 @Index(['ride', 'lastUpdated']) // Optimizes the duplicate check query
 @Index(['ride', 'lastUpdated', 'waitTime']) // Additional index for full duplicate prevention
+@Index(['ride']) // Speeds up queries filtering by ride ID
+@Index(['ride', 'isOpen', 'lastUpdated']) // Speeds up historical queries used for crowd level
 export class QueueTime {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/modules/parks/weather-background.service.ts
+++ b/src/modules/parks/weather-background.service.ts
@@ -288,7 +288,8 @@ export class WeatherBackgroundService implements OnModuleInit {
       for (const entry of expiredEntries) {
         try {
           // Create historical entry
-          const historicalId = `park_${entry.parkId}_${entry.weatherDate.toISOString().split('T')[0]}_historical`;
+          const weatherDateObj = entry.weatherDate instanceof Date ? entry.weatherDate : new Date(entry.weatherDate);
+          const historicalId = `park_${entry.parkId}_${weatherDateObj.toISOString().split('T')[0]}_historical`;
 
           // Check if historical entry already exists
           const existingHistorical = await this.databaseCacheService[
@@ -301,7 +302,7 @@ export class WeatherBackgroundService implements OnModuleInit {
             ].create({
               id: historicalId,
               parkId: entry.parkId,
-              weatherDate: entry.weatherDate,
+              weatherDate: weatherDateObj,
               dataType: WeatherDataType.HISTORICAL,
               temperatureMin: entry.temperatureMin,
               temperatureMax: entry.temperatureMax,
@@ -319,7 +320,7 @@ export class WeatherBackgroundService implements OnModuleInit {
             convertedCount++;
 
             this.logger.debug(
-              `Converted expired current weather for park ${entry.parkId} on ${entry.weatherDate.toISOString().split('T')[0]} to historical`,
+              `Converted expired current weather for park ${entry.parkId} on ${weatherDateObj.toISOString().split('T')[0]} to historical`,
             );
           }
         } catch (error) {

--- a/src/modules/rides/rides.service.ts
+++ b/src/modules/rides/rides.service.ts
@@ -98,21 +98,21 @@ export class RidesService {
    * Get a specific ride by ID with current queue time only
    */
   async findOne(id: number) {
-    const ride = await this.rideRepository
-      .createQueryBuilder('ride')
-      .leftJoinAndSelect('ride.park', 'park')
-      .leftJoinAndSelect('ride.themeArea', 'themeArea')
-      .leftJoinAndSelect('ride.queueTimes', 'queueTimes')
-      .where('ride.id = :id', { id })
-      .orderBy('queueTimes.recordedAt', 'DESC')
-      .getOne();
+    const ride = await this.rideRepository.findOne({
+      where: { id },
+      relations: {
+        park: true,
+        themeArea: true,
+      },
+    });
 
     if (!ride) {
       throw new NotFoundException(`Ride with ID ${id} not found`);
     }
 
-    // Get the most recent queue time for this ride
-    const currentQueueTime = this.getCurrentQueueTime(ride);
+    const currentQueueTime = await this.parkUtils.getCurrentQueueTimeFromDb(
+      ride.id,
+    );
 
     return {
       id: ride.id,

--- a/src/modules/utils/park-utils.service.spec.ts
+++ b/src/modules/utils/park-utils.service.spec.ts
@@ -1,6 +1,9 @@
 import { Test } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { ParkUtilsService } from './park-utils.service';
+import { Ride } from '../parks/ride.entity';
+import { QueueTime } from '../parks/queue-time.entity';
 
 describe('ParkUtilsService', () => {
   let service: ParkUtilsService;
@@ -8,7 +11,14 @@ describe('ParkUtilsService', () => {
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [ConfigModule.forRoot({ isGlobal: true })],
-      providers: [ParkUtilsService],
+      providers: [
+        ParkUtilsService,
+        { provide: getRepositoryToken(Ride), useValue: {} },
+        {
+          provide: getRepositoryToken(QueueTime),
+          useValue: { query: jest.fn() },
+        },
+      ],
     }).compile();
 
     service = moduleRef.get(ParkUtilsService);

--- a/src/modules/utils/utils.module.ts
+++ b/src/modules/utils/utils.module.ts
@@ -1,5 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Ride } from '../parks/ride.entity';
+import { QueueTime } from '../parks/queue-time.entity';
 import { ParkUtilsService } from './park-utils.service.js';
 import { ReadmeService } from './readme.service.js';
 import { CacheControlInterceptor } from './cache-control.interceptor.js';
@@ -7,7 +10,7 @@ import { HierarchicalUrlService } from './hierarchical-url.service.js';
 import { HierarchicalUrlInjectorService } from './hierarchical-url-injector.service.js';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, TypeOrmModule.forFeature([Ride, QueueTime])],
   providers: [
     ParkUtilsService,
     ReadmeService,
@@ -21,6 +24,7 @@ import { HierarchicalUrlInjectorService } from './hierarchical-url-injector.serv
     CacheControlInterceptor,
     HierarchicalUrlService,
     HierarchicalUrlInjectorService,
+    TypeOrmModule,
   ],
 })
 export class UtilsModule {}


### PR DESCRIPTION
## Summary
- import TypeORM support into utils module
- add direct ride index for faster queries
- support DB-backed queue time lookups in `ParkUtilsService`
- compute park open status with SQL in park util service
- use new util methods in parks service
- fetch latest queue time in ride detail instead of full history
- optimize crowd level calculations

## Testing
- `pnpm run lint` *(fails: @typescript-eslint errors)*
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68599469fe9883258eb49e4fd0a96c3b