### PR TITLE
Add healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Stage 1: Build
+FROM node:24-alpine AS builder
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install
+COPY . .
+RUN pnpm run build
+
+# Stage 2: Production
+FROM node:24-alpine
+WORKDIR /app
+RUN corepack enable \
+  && apk add --no-cache curl
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --prod
+COPY --from=builder /app/dist ./dist
+ENV NODE_ENV=production
+CMD ["node", "dist/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    environment:
+      - NODE_ENV=production
+    ports:
+      - "${PORT:-3000}:3000"
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5


### PR DESCRIPTION
## Summary
- install `curl` in Dockerfile to support health checks
- add a `/status` healthcheck to docker-compose

## Testing
- `pnpm install`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a6e77970c8325b6fa884d70284a3d